### PR TITLE
feat/extension

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -1,0 +1,32 @@
+chrome.runtime.onInstalled.addListener(() => {
+    console.log("차단 페이지로 이동됨.");
+});
+
+// 사이트 요청 가로채서 백엔드 분석 결과에 따라 차단 여부 결정
+chrome.webRequest.onBeforeRequest.addListener(
+  async (details) => {
+    const url = details.url;
+
+    try {
+      const response = await fetch("백엔드 서버 주소 넣기/predict", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ url })
+      });
+
+      const result = await response.json();
+      console.log("[REAGAN] 분석 결과:", result);
+
+      if (result.phishing === true) {
+        console.warn("[REAGAN] 차단됨:", url);
+        return { cancel: true }; // 탐지된 피싱 사이트는 차단
+      }
+    } catch (e) {
+      console.error("[REAGAN] 분석 중 오류:", e);
+    }
+
+    return { cancel: false }; // 탐지 실패 또는 정상: 접속 허용
+  },
+  { urls: ["<all_urls>"] },
+  ["blocking"]
+);

--- a/extension/blocked.css
+++ b/extension/blocked.css
@@ -1,0 +1,10 @@
+body {
+    font-family: sans-serif;
+    text-align: center;
+    padding: 2em;
+    background-color: #fff0f0;
+}
+
+h1 {
+    color: #d33;
+}

--- a/extension/blocked.html
+++ b/extension/blocked.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8" />
+    <title>접속 차단됨</title>
+    <link rel="stylesheet" href="blocked.css" />
+</head>
+<body>
+<h1 id="icon" class="icon danger">악성 페이지 판별</h1>
+<p id="label">초 위험한 사이트입니다.</p>
+</body>
+</html>

--- a/extension/content.js
+++ b/extension/content.js
@@ -1,27 +1,14 @@
 (async () => {
-    const html = document.documentElement.outerHTML;
-    const scripts = Array.from(document.scripts).map(s => s.innerText).join("\n");
-
-    const styles = Array.from(document.styleSheets)
-        .map(sheet => {
-            try {
-                return Array.from(sheet.cssRules || []).map(rule => rule.cssText).join("\n");
-            } catch (e) {
-                return ""; // CORS 등 접근 불가 예외 무시,
-            }
-        })
-        .join("\n");
-
     // data 객체로 묶어서 나중에 백으로 보내기
     const data = {
-        url: window.location.href,
-        html: html,
-        scripts: scripts,
-        styles: styles
+        site_url: window.location.href
     };
 
+    console.log("[REAGAN] 전송 데이터 확인:", data);
+
     // 백엔드 서버로 전송 JSON 형식
-    fetch("여기에 백엔드 서버 주소 추가할 것 (까먹으면 클남)", {
+    // 테스트를 위해 임시로 서버 주소 넣었음 나중에 바꿀것
+    fetch("백엔드 서버 주소 넣기/api/analysis-requests", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(data)
@@ -29,8 +16,15 @@
         .then(res => res.json())
         .then(result => {
             console.log("[REAGAN] 분석 결과:", result);
-            // 백 연동하면 저장된 결과값을 chrome.storage.local 에서 get 으로 받아오면 됨
             chrome.storage.local.set({ reagan_result: result });
+
+            if (result.html_result?.phishing || result.url_result?.phishing) {
+                const confirmBlock = confirm("이 사이트는 위험할 수 있습니다. 그래도 접속하시겠습니까?");
+                if (!confirmBlock) {
+                    const redirectUrl = chrome.runtime.getURL("blocked.html") + `?original=${encodeURIComponent(window.location.href)}`;
+                    window.location.replace(redirectUrl);
+                }
+            }
         })
         .catch(err => console.error("[REAGAN] 전송 실패:", err));
 })();

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,10 +1,19 @@
 {
+  "web_accessible_resources": [
+    {
+      "resources": ["blocked.html", "blocked.css", "blocked.js"],
+      "matches": ["<all_urls>"]
+    }
+  ],
   "manifest_version": 3,
   "name": "Reagan Phishing Detector",
   "version": "1.0",
   "description": "Detect phishing pages using AI via static code analysis.",
-  "permissions": ["scripting", "activeTab"],
-  "host_permissions": ["<all_urls>"],
+  "permissions": ["scripting", "activeTab", "storage", "webRequest", "webRequestBlocking", "tabs"],
+  "host_permissions": ["http://localhost:5000/*", "<all_urls>"],
+  "background": {
+    "service_worker": "background.js"
+  },
   "action": {
     "default_popup": "popup.html",
     "default_icon": {

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -34,6 +34,59 @@
 <body>
 <div id="icon" class="icon">WAIT</div>
 <div id="label" class="label">분석 중...</div>
-<script src="popup.js"></script>
+<script>
+    document.addEventListener("DOMContentLoaded", () => {
+        const icon = document.getElementById("icon");
+        const label = document.getElementById("label");
+
+        chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
+            const siteUrl = tabs[0].url;
+            // 백엔드 주소는 수정하기 (어딨는지를 모르겠음)
+            fetch("백엔드 주소 수정하기/api/analysis-requests", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ site_url: siteUrl })
+            })
+                .then(res => res.json())
+                .then(data => {
+                    const requestId = data.request_id;
+
+                    const interval = setInterval(() => {
+                        fetch(`http://127.0.0.1:5000/api/analysis-requests/${requestId}`)
+                            .then(res => res.json())
+                            .then(details => {
+                                if (details.overall_status === "completed") {
+                                    clearInterval(interval);
+
+                                    const task = details.tasks.find(t => t.task_type === "site_analysis");
+                                    const isPhishing = task?.result?.vulnerabilities?.length > 0;
+
+                                    if (isPhishing) {
+                                        icon.textContent = "DETECT";
+                                        icon.className = "icon danger";
+                                        label.textContent = "위험합니다.";
+                                    } else {
+                                        icon.textContent = "SAFE";
+                                        icon.className = "icon safe";
+                                        label.textContent = "안전합니다.";
+                                    }
+                                }
+                            })
+                            .catch(err => {
+                                console.error("분석 실패", err);
+                                clearInterval(interval);
+                                icon.textContent = "FAIL";
+                                label.textContent = "판별 실패";
+                            });
+                    }, 2000);
+                })
+                .catch(err => {
+                    console.error("분석 요청 실패", err);
+                    icon.textContent = "FAIL";
+                    label.textContent = "판별 실패";
+                });
+        });
+    });
+</script>
 </body>
 </html>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -1,48 +1,29 @@
 document.addEventListener("DOMContentLoaded", () => {
-    // 그냥 기본 표시
-    icon.textContent = "WAIT";
-    icon.className = "icon loading";
-    label.textContent = "분석 중...";
+    const icon = document.getElementById("icon");
+    const label = document.getElementById("label");
 
-    // 프론트 테스트용 코드 나중에 백엔드 연동 시 삭제 예정
-    const result = {
-        phishing: true, // ← false로 바꾸면 "SAFE" 뜸
-        confidence: 0.97,
-        reason: "의심스러운 URL이 감지되었습니다."
-    };
+    chrome.storage.local.get("reagan_result", data => {
+        const result = data.reagan_result;
 
-    // 결과
-    if (result.phishing === true) {
-        icon.textContent = "DETECT";
-        icon.className = "icon danger";
-        label.textContent = "위험합니다.";
-    } else if (result.phishing === false) {
-        icon.textContent = "SAFE";
-        icon.className = "icon safe";
-        label.textContent = "안전합니다.";
-    } else {
-        icon.textContent = "FAIL";
-        label.textContent = "판별 실패"; // 이건 그냥 넣어봄 근데 거의 뜰일 없을듯?
-    }
+        if (!result) {
+            icon.textContent = "WAIT";
+            icon.className = "icon loading";
+            label.textContent = "분석 중...";
+            return;
+        }
 
-
-    // 나중에 백엔드 완성되고 연동하면 아래 코드로 변경하기
-    // 그냥 storage.local.get 으로 결과값만 저장해서 사용하는 코드임
-    // chrome.storage.local.get("reagan_result", data => {
-    //     const result = data.reagan_result;
-    //     if (!result) return;
-
-    //     if (result.phishing === true) {
-    //         icon.textContent = "DETECT";
-    //         icon.className = "icon danger";
-    //         label.textContent = "위험합니다.";
-    //     } else if (result.phishing === false) {
-    //         icon.textContent = "SAFE";
-    //         icon.className = "icon safe";
-    //         label.textContent = "안전합니다.";
-    //     } else {
-    //         icon.textContent = "FAIL";
-    //         label.textContent = "판별 실패";
-    //     }
-    // });
+        if (result.phishing === true) {
+            icon.textContent = "DETECT";
+            icon.className = "icon danger";
+            label.textContent = "매우 위험.";
+        } else if (result.phishing === false) {
+            icon.textContent = "SAFE";
+            icon.className = "icon safe";
+            label.textContent = "극히 안전.";
+        } else {
+            icon.textContent = "FAIL";
+            icon.className = "icon";
+            label.textContent = "판별 실패";
+        }
+    });
 });


### PR DESCRIPTION
* manifest 몇 가지 수정 사항

"web_accessible_resources": [
    {
      "resources": ["blocked.html", "blocked.css", "blocked.js"],
      "matches": ["<all_urls>"]
    }
  ] 
추가 및 permissions 추가

* API 명세에 맞춰 JSON 변환

* 로컬에서 mock_backend 추가하여 테스트 진행

<img width="1379" alt="스크린샷 2025-05-26 오후 1 46 16" src="https://github.com/user-attachments/assets/10970b83-29da-4b5c-8932-56c052b3fd84" />

사이트 접속 시 위와 같이 팝업 창이 뜨게 되고 취소를 선택할 경우 blocked.html 로 자동 리다이렉션
확인을 선택할 경우 접속 시도했던 사이트로 이동
하단의 이미지는 blocked.html 의 모습


<img width="1353" alt="스크린샷 2025-05-26 오후 2 20 04" src="https://github.com/user-attachments/assets/07d4065d-96a7-47df-b152-fc6a272f877e" />


JSON 에 담겨오는 데이터는 mock 에 있는 가상 DB 속 데이터
<img width="416" alt="스크린샷 2025-05-26 오후 2 52 11" src="https://github.com/user-attachments/assets/a8e7b805-b056-4e0c-bee8-e4792ce9ebe1" />


다만 실제로 접속을 차단한 것이 아니라 시각적으로만 변화를 주었습니다.
접속 차단은 구글 확장 프로그램의 권한을 넘어서는 일이기에 만일 동일한 기능을 구현하고자 한다면
DOM 내부에 직접 메시지를 작성해야 합니다.

<img width="656" alt="스크린샷 2025-05-26 오후 2 21 14" src="https://github.com/user-attachments/assets/83223299-b5cb-4c80-8c57-294951fb0283" />

팝업 창 또한 자동으로 표시되게끔 하는 것은 권한 밖의 일이기에
분석 세부 내용 표시 와 같은 기능으로의 변경을 고려해야 합니다.

확인 부탁드립니다.



